### PR TITLE
test(aws-cli):create, list and abort a multipart upload using aws-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Collection of simple scripts to consume object storage APIs and gather metrics.
 
 - [aws-cli](https://aws.amazon.com/cli/)
 - [k6](https://github.com/grafana/k6)
+  - with [xk6-exec](https://github.com/grafana/xk6-exec) extension
 - [rclone](https://rclone.org/)
 - [just](https://just.systems/)
 - [dasel](https://github.com/TomWright/dasel)
@@ -12,6 +13,16 @@ Collection of simple scripts to consume object storage APIs and gather metrics.
 - [openssl](https://www.openssl.org/docs/man1.0.2/man1/openssl.html)
 
 ## Setup
+
+### bundle xk6-exec extension on k6
+
+```
+# generate new binary
+docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build v0.43.1 --with github.com/grafana/xk6-exec@v0.3.0
+
+# overwrite existing k6 with the new one
+sudo cp -f ./k6 `which k6`
+```
 
 ### rclone
 

--- a/justfile
+++ b/justfile
@@ -119,6 +119,7 @@ _k6-run remote testname bucket_name results_dir:
   k6 run src/k6/{{testname}}.js \
     --vus={{k6_vus}} --iterations={{k6_iterations}} \
     --out json={{results_dir}}/k6-{{testname}}.json \
+    --env AWS_CLI_PROFILE={{remote}} \
     --env S3_TEST_BUCKET_NAME={{bucket_name}} \
     --env S3_ACCESS_KEY_ID=`dasel -f .remote.{{remote}}.yml 'access_key_id'` \
     --env S3_SECRET_ACCESS_KEY=`dasel -f .remote.{{remote}}.yml 'secret_access_key'` \
@@ -131,6 +132,7 @@ _k6-run remote testname bucket_name results_dir:
 __test-k6 remote unique_sufix results_dir:
   # create local folder for storing results
   mkdir -p {{results_dir}}
+  @just _k6-run {{remote}} aws-cli-objects {{k6_test_bucket}}{{unique_sufix}} {{results_dir}}
   # TODO: remove this mkdir once k6 is able to create buckets
   #       see: https://github.com/grafana/k6-jslib-aws/issues/69
   rclone mkdir {{remote}}:{{k6_test_bucket}}{{unique_sufix}}

--- a/src/k6/aws-cli-objects.js
+++ b/src/k6/aws-cli-objects.js
@@ -1,0 +1,72 @@
+import exec from 'k6/x/exec';
+import { check, fail } from 'k6'
+import { crypto } from "k6/experimental/webcrypto"
+
+const profileName = __ENV.AWS_CLI_PROFILE
+const endpoint = __ENV.S3_ENDPOINT
+
+function s3api(cmdName, bucketName, args){
+  return exec.command("aws", [
+    "s3api",
+    "--profile", profileName,
+    "--endpoint", endpoint,
+    cmdName,
+    "--bucket", bucketName,
+    ...args,
+  ])
+}
+
+export function setup() {
+  // create bucket to be used by the tests
+  const bucketName = `test-aws-cli-${crypto.randomUUID()}`
+  console.log(s3api("create-bucket", bucketName, []))
+  return {bucketName}
+}
+
+export function teardown({bucketName}) {
+  // delete bucket used by the tests
+  console.log(s3api("delete-bucket", bucketName, []))
+}
+
+export default function scenarios(data) {
+  createMultipartUpload(data)
+}
+
+export function createMultipartUpload({bucketName}){
+  const keyName = crypto.randomUUID()
+
+  // create the multipart upload
+  let stdOut = s3api("create-multipart-upload", bucketName, [
+    "--key", keyName
+  ])
+  console.info("Create Output", stdOut)
+  let parsedResult;
+  try {
+    parsedResult = JSON.parse(stdOut)
+  } catch(e) {
+    console.error(e)
+    fail('Unparseable create-multipart-upload response')
+  }
+  const uploadId = parsedResult.UploadId 
+  check(uploadId, {
+    'CLI returns a response with UploadId': id => id !== undefined,
+  })
+
+  // list multipart uploads
+  stdOut = s3api("list-multipart-uploads", bucketName, [])
+  console.info("List Output", stdOut)
+  check(stdOut, {
+    'In-progress multipart uploads list the key': s => s.includes(keyName),
+    'In-progress multipart uploads list the upload ID': s => s.includes(uploadId),
+  })
+
+  // TBD: upload parts
+
+  // abort the multipart upload
+  stdOut = s3api("abort-multipart-upload", bucketName, [
+    "--key", keyName,
+    "--upload-id", uploadId, 
+  ])
+  console.info("Abort Output:", stdOut)
+  
+}


### PR DESCRIPTION
Similar to https://github.com/marmotitude/object-storage-tests/pull/6 but using aws-cli instead of k6-jslib-aws, the main diffrence is that aws-cli uses path-style endpoints instead of virtual-hosted-style.