### PR TITLE
fix(boto3-presigned):do the ls against the folder

### DIFF
--- a/src/k6/boto3-presigned.js
+++ b/src/k6/boto3-presigned.js
@@ -40,7 +40,7 @@ export function presignPut({bucketName}){
 }
 
 export function listObject({bucketName}){
-  const list = (aws(s3Config, "s3", ["ls", `s3://${bucketName}/${testFileName}`]))
+  const list = aws(s3Config, "s3", ["ls", `s3://${bucketName}`])
   console.log(`List s3=${list}`)
   check(list, {"[List] response contains object name":l => l.includes(testFileName)})
 }


### PR DESCRIPTION
This patch changes the check to see if the upload file is there by listing the contents of the existing buckets and looking for the file instead of doing the ls on the file itself, that was causing the command to exit 1 when the upload failed. With this small tweak only the check fails and not the command.