### PR TITLE
Html results

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Fabricio C Zuardi <@fczuardi>
 Eduardo Trindade <@jets->
 Bruno Fernandes <@folkzb>
+OpenAI's ChatGPT <@OpenAI>

--- a/justfile
+++ b/justfile
@@ -62,7 +62,7 @@ group-test test_name group_name +remotes: _setup
   # parallel_processes=2
   # printf "%s\0" {{remotes}} | xargs -0 -I @ -P $parallel_processes just test @ {{test_name}}
   for remote in {{remotes}}; do
-    just test $remote {{test_name}}
+    just test $remote {{test_name}} || true
   done
   # Group all json files of remotes dirs, from the past 10 minutes, into a single one
   cd {{results_prefix}}

--- a/justfile
+++ b/justfile
@@ -73,7 +73,8 @@ group-test test_name group_name +remotes: _setup
   results_json_file={{results_prefix}}/{{group_name}}/{{date}}/results.json
   results_yaml_file={{results_prefix}}/{{group_name}}/{{date}}/results.yaml
   results_html_file={{results_prefix}}/{{group_name}}/{{date}}/report.html
-  ./src/tag-report.py $results_json_file > $results_yaml_file
+  set -x
+  ./src/tag-report.py $results_json_file '{{remotes}}' > $results_yaml_file
   gotpl src/templates/report.html -f $results_yaml_file -o $results_dir
   echo results saved to $results_json_file, $results_yaml_file and $results_html_file
 

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@
 #------------------------
 date := `date +%Y%m%d-%H%M%S`
 config_file := env_var_or_default("CONFIG_PATH", "./") + "config.yaml"
+results_prefix := "results"
 rclone_conf_exists := path_exists(env_var("HOME") + "/.config/rclone")
 aws_conf_exists := path_exists(env_var("HOME") + "/.aws")
 
@@ -118,14 +119,12 @@ _k6-run remote testname results_dir *args:
     --console-output="{{results_dir}}/k6-{{testname}}.console.log" \
     {{args}} 2>&1 | tee "{{results_dir}}/k6-{{testname}}.log"
 
-__test-k6 remote test_name results_dir:
-  #!/usr/bin/env sh
-  # create local folder for storing results
-  mkdir -p {{results_dir}}
-  just _k6-run {{remote}} {{test_name}} {{results_dir}}
-
 _test-k6 remote test_name timestamp:
-  @just __test-k6 {{remote}} {{test_name}} {{results_prefix}}/{{remote}}/{{timestamp}}
+  #!/usr/bin/env sh
+  results_dir={{results_prefix}}/{{remote}}/{{timestamp}}
+  # create local folder for storing results
+  mkdir -p $results_dir
+  just _k6-run {{remote}} {{test_name}} $results_dir
 
 
 #------------------
@@ -141,7 +140,6 @@ s3api_test_bucket := "test-aws-cli-s3api-"
 
 # rclone
 test_dir := "test-rclone-"
-results_prefix := "results"
 rclone_conf := "~/.config/rclone/rclone.conf"
 # https://rclone.org/commands/rclone_test_makefiles/
 rclone_files_count := "50"

--- a/src/k6/aws-cli-presigned.js
+++ b/src/k6/aws-cli-presigned.js
@@ -41,7 +41,6 @@ export function presignGet({bucketName}) {
 
   // generate presigned (GET) url using AWS-CLI
   checkTags = {
-    feature: tags.features.CREATE_PRESIGN_GET_URL_V2,
     tool: tags.tools.CLI_AWS,
     command: tags.commands.CLI_AWS_S3_PRESIGN,
   }
@@ -53,8 +52,8 @@ export function presignGet({bucketName}) {
 
   // download testFile using GET on that url before the expirantion date
   checkTags = {
-    feature: tags.features.GET_OBJECT,
     tool: tags.tools.HTTP,
+    feature: tags.features.GET_OBJECT_PRESIGNED_V2,
     command: tags.commands.HTTP_GET,
   }
   const res = http.get(url.trim())

--- a/src/k6/boto3-presigned.js
+++ b/src/k6/boto3-presigned.js
@@ -29,7 +29,6 @@ export function presignPut({bucketName}){
     __ENV.AWS_CLI_PROFILE, 'generate-put-url', bucketName, testFileName])
   console.log(url)
   let checkTags = {
-    feature: tags.features.CREATE_PRESIGN_PUT_URL,
     tool: tags.tools.LIB_PYTHON_BOTO3,
     command: tags.commands.LIB_PYTHON_BOTO3_CLIENT_GENERATE_PRESIGNED_URL,
   }
@@ -49,14 +48,23 @@ export function presignPut({bucketName}){
     check(res.status, {
       [`${checkTags.command}`]: s => s === 200 }, checkTags)
 
-    const list = aws(s3Config, "s3", ["ls", `s3://${bucketName}`])
-    console.log(`s3 ls = ${list}`)
+    let lsOutput = aws(s3Config, "s3", ["ls", `s3://${bucketName}`])
+    console.log(`s3 ls = ${lsOutput}`)
+    let command = tags.commands.CLI_AWS_S3_LS
     checkTags = {
       feature: tags.features.LIST_BUCKET_OBJECTS,
       tool: tags.tools.CLI_AWS,
-      command: tags.commands.CLI_AWS_S3_LS,
+      command,
     }
-    check(list, {
-      [`${checkTags.command} contains uploaded object`]:l => l.includes(testFileName)}, checkTags)
-    })
+    check(lsOutput, {
+      [`${command}`]: l => l !== undefined
+    }, checkTags)
+
+    checkTags = {
+      feature: tags.features.PUT_OBJECT_PRESIGNED,
+    }
+    check(lsOutput, {
+      [`${command} contains uploaded object`]: l => l.includes(testFileName)
+    }, checkTags)
+  })
 }

--- a/src/k6/k6-jslib-objects.js
+++ b/src/k6/k6-jslib-objects.js
@@ -81,7 +81,7 @@ export async function abortMultipart({bucketName}) {
     }, checkTags)
 
     checkTags = {
-      feature: tags.features.ABORT_MULTIPART,
+      feature: tags.features.PUT_OBJECT_MULTIPART,
       tool: tags.tools.LIB_JS_K6_AWS,
       command: tags.commands.LIB_JS_K6_AWS_S3CLIENT_ABORT_MULTIPART,
     };

--- a/src/k6/utils/tags.js
+++ b/src/k6/utils/tags.js
@@ -13,6 +13,13 @@ const tags = {
     GET_OBJECT: "get object",
     PUT_OBJECT_PRESIGNED: "put object (presigned)",
     GET_OBJECT_PRESIGNED: "get object (presigned)",
+
+    // multipart objects
+    CREATE_MULTIPART_UPLOAD: "start multipart upload",
+    LIST_MULTIPART_UPLOADS: "list ongoing multipart uploads",
+    UPLOAD_MULTIPART_PART: "upload part of a multipart",
+    LIST_MULTIPART_UPLOAD_PARTS: "list parts of a multipart upload",
+    ABORT_MULTIPART_UPLOAD: "abort multipart upload",
     PUT_OBJECT_MULTIPART: "put object (multipart)",
 
     // temporary URLs

--- a/src/k6/utils/tags.js
+++ b/src/k6/utils/tags.js
@@ -13,6 +13,7 @@ const tags = {
     GET_OBJECT: "get object",
     PUT_OBJECT_PRESIGNED: "put object (presigned)",
     GET_OBJECT_PRESIGNED: "get object (presigned)",
+    GET_OBJECT_PRESIGNED_V2: "get object (presigned v2)",
 
     // multipart objects
     CREATE_MULTIPART_UPLOAD: "start multipart upload",
@@ -26,7 +27,6 @@ const tags = {
     CREATE_PRESIGN_PUT_URL: "create v4 presign upload URL",
     CREATE_PRESIGN_GET_URL: "create v4 presign download URL",
     CREATE_PRESIGN_PUT_URL_V2: "create v2 presign upload URL",
-    CREATE_PRESIGN_GET_URL_V2: "create v2 presign download URL",
   },
   tools: {
     CLI_AWS: "aws cli",

--- a/src/tag-report.py
+++ b/src/tag-report.py
@@ -82,7 +82,7 @@ processed_data: ProcessedData = {
     'section_titles': section_titles,
     'tags_order': tags_order,
     'tags': {
-        tag: tag_counts[tag] for tag in tags_order
+        tag: tag_counts.get(tag) for tag in tags_order
     }
 }
 

--- a/src/tag-report.py
+++ b/src/tag-report.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import sys
+import json
+import yaml
+from typing import Dict, List, TypedDict
+
+# Check if the correct number of command line arguments is provided
+if len(sys.argv) != 2:
+    print("Usage: ./script.py <k6_log.json>")
+    sys.exit(1)
+
+input_file = sys.argv[1]
+
+# Define types for the yaml output structure
+RemoteName = str
+SuccessCount = int
+TotalChecks = int
+TagName = str
+
+class RemoteSuccessCount(TypedDict):
+    success: SuccessCount
+    total: TotalChecks
+
+TagSummary = Dict[TagName, Dict[RemoteName, RemoteSuccessCount]]
+
+class TestPeriod(TypedDict):
+    begin: str
+    end: str
+
+class ProcessedData(TypedDict):
+    period: TestPeriod
+    remotes: List[RemoteName]
+    section_titles: List[str]
+    tags_order: List[TagName]
+    tags: TagSummary
+
+# Read k6 JSON output file line by line
+tag_counts: Dict[TagName, TagSummary] = {}
+remotes_set: set[RemoteName] = set()
+oldest_check_time = None
+most_recent_check_time = None
+
+try:
+    with open(input_file, 'r') as file:
+        for line in file:
+            try:
+                entry = json.loads(line)
+                if 'data' in entry and 'tags' in entry['data'] and entry['metric'] == "checks":
+                    check_time = entry['data']['time']
+                    if oldest_check_time is None or check_time < oldest_check_time:
+                        oldest_check_time = check_time
+                    if most_recent_check_time is None or check_time > most_recent_check_time:
+                        most_recent_check_time = check_time
+
+                    tags = entry['data']['tags']
+                    remote = tags.get('remote', None)
+                    remotes_set.add(remote)  # Add remote to the set
+                    value = entry['data']['value']
+                    for tag, tag_value in tags.items():
+                        if tag == 'remote':
+                            continue
+                        tag_counts.setdefault(tag, {}).setdefault(tag_value, {}).setdefault(remote, {'success': 0, 'total': 0})
+                        tag_counts[tag][tag_value][remote]['total'] += 1
+                        if value == 1:
+                            tag_counts[tag][tag_value][remote]['success'] += 1
+            except json.JSONDecodeError:
+                print(f"Skipping invalid JSON: {line}")
+except FileNotFoundError:
+    print(f"Error: File '{input_file}' not found.")
+    sys.exit(1)
+
+# Output processed data and remotes as YAML to stdout
+tags_order = ["feature", "tool", "command", "fix"]
+section_titles = ["Features", "Tools", "Commands", "Fixes"]
+
+processed_data: ProcessedData = {
+    'period': {
+      'begin': oldest_check_time,
+      'end': most_recent_check_time,
+    },
+    'remotes': list(remotes_set),  # Convert set to list for YAML output
+    'section_titles': section_titles,
+    'tags_order': tags_order,
+    'tags': {
+        tag: tag_counts[tag] for tag in tags_order
+    }
+}
+
+try:
+    yaml.dump(processed_data, sys.stdout, default_flow_style=False)
+except IOError:
+    print('Error: Unable to write YAML data to stdout')
+

--- a/src/tag-report.py
+++ b/src/tag-report.py
@@ -6,7 +6,7 @@ from typing import Dict, List, TypedDict
 
 # Check if the correct number of command line arguments is provided
 if len(sys.argv) != 2:
-    print("Usage: ./script.py <k6_log.json>")
+    print("Usage: ./tag-report.py results.json > results.yaml")
     sys.exit(1)
 
 input_file = sys.argv[1]

--- a/src/templates/report.html
+++ b/src/templates/report.html
@@ -1,0 +1,33 @@
+<h1>Checks from {{ printf "%.16s" .period.begin }} to {{ printf "%.16s" .period.end }}</h1>
+{{range $i,$tag := .tags_order}}
+<section>
+  <h2>{{index $.section_titles $i}}</h2>
+  <table border="1">
+    <thead>
+      <tr>
+        <th rowspan=2>{{ $tag }}</th>
+        <th colspan="{{ len $.remotes }}">Success Count</th>
+      </tr>
+      <tr>
+        {{range $.remotes}}
+          <th>{{.}}</th>
+        {{end}}
+      </tr>
+    </thead>
+    <tbody>
+      {{range $name, $remotes := index $.tags $tag}}
+        <tr>
+          <td>{{$name}}</td>
+          {{range $.remotes}}
+            {{with index $remotes .}}
+              <td>{{.success}}/{{.total}}</td>
+            {{else}}
+              <td>-</td>
+            {{end}}
+          {{end}}
+        </tr>
+      {{end}}
+    </tbody>
+  </table>
+</section>
+{{end}}

--- a/src/templates/report.html
+++ b/src/templates/report.html
@@ -1,3 +1,8 @@
+<style>
+td {
+  padding: 0.5rem;
+}
+</style>
 <h1>Checks from {{ printf "%.16s" .period.begin }} to {{ printf "%.16s" .period.end }}</h1>
 {{range $i,$tag := .tags_order}}
 <section>

--- a/src/templates/report.html
+++ b/src/templates/report.html
@@ -2,6 +2,9 @@
 td {
   padding: 0.5rem;
 }
+.warn {
+  background-color: lightyellow
+}
 </style>
 <h1>Checks from {{ printf "%.16s" .period.begin }} to {{ printf "%.16s" .period.end }}</h1>
 {{range $i,$tag := .tags_order}}
@@ -25,7 +28,7 @@ td {
           <td>{{$name}}</td>
           {{range $.remotes}}
             {{with index $remotes .}}
-              <td>{{.success}}/{{.total}}</td>
+              <td{{ if ne .success .total }} class="warn"{{ end }}>{{.success}}/{{.total}}</td>
             {{else}}
               <td>-</td>
             {{end}}


### PR DESCRIPTION
Fix #47 

Cria um script python que processa o output json do k6 agrupando tags usadas nos checks, em especial 3 delas: "feature", "tool" e "command" que estamos usando para marcar testes que testam se uma funcionalidade de uma ferramenta está funcionando. Este mesmo script agrupa estas 3 categorias para cada "remote", que é cada diferente provedor de object storage.

O output deste script python é um yaml.

Este patch também inclui um template go simples que a partir dos dados do yaml gera uma pagina html com 3 tabelas.

Este patch introduz também uma nova receita no just, para rodar um determinado teste em multiplos remotes, concatenar os resultados e criar um report em html baseado no script python e no template go.