### PR TITLE
feat: add option of prometheus metrics output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN cp linux-amd64/gotpl /app
 # main image
 FROM alpine:3.18.5
 RUN apk update && \
-    apk add coreutils aws-cli rclone \
-            just openssl dasel
+      apk add coreutils aws-cli rclone \
+      just openssl dasel
 COPY --from=k6builder /app/k6 /usr/bin/k6
 COPY --from=gotplbuilder /app/gotpl /usr/bin/gotpl
 
@@ -38,6 +38,7 @@ COPY justfile /app/justfile
 COPY run_tests.sh /app/run_tests.sh
 COPY requirements.txt /app/requirements.txt
 COPY LICENSE /app/LICENSE
+COPY config.yaml /app/config.yaml
 RUN pip install --no-cache-dir --no-dependencies -r requirements.txt
 RUN mkdir /app/config
 ENTRYPOINT ["just", "-f", "/app/justfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ COPY justfile /app/justfile
 COPY run_tests.sh /app/run_tests.sh
 COPY requirements.txt /app/requirements.txt
 COPY LICENSE /app/LICENSE
-COPY config.yaml /app/config.yaml
 RUN pip install --no-cache-dir --no-dependencies -r requirements.txt
 RUN mkdir /app/config
 ENTRYPOINT ["just", "-f", "/app/justfile"]

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ vim config.yaml #edit with your remotes
 
 The output format of the test results can be controlled via the `prometheus_rw_url` variable in the `config.yaml` file. This allows for flexibility in how you wish to view and use your test data.
 
-- **JSON Output (Default)**: If the `prometheus_rw_url` variable is not set or is left empty in the `config.yaml`, the test results will be output in JSON format. This is the default behavior and is suitable for scenarios where JSON formatted data is required for analysis or integration, like in a `webapp` tagged image.
+- **JSON Output (Default)**: System will always output JSON.
 
-- **Prometheus Metrics Output**: If you set a value for `prometheus_rw_url` in the `config.yaml`, the test results will be output as Prometheus metrics. This is useful for integrating with monitoring systems that are compatible with Prometheus.
+- **Prometheus Metrics Output**: If you set a value for `prometheus_rw_url` in the `config.yaml`, the test results will be also outputed as Prometheus metrics. This is useful for integrating with monitoring systems that are compatible with Prometheus.
 
 Example configuration in `config.yaml`:
 
 ```yaml
-prometheus_rw_url: "http://your-prometheus-server:port/api/v1/write"  # Outputs Prometheus metrics
+prometheus_rw_url: "http://your-prometheus-server:port/api/v1/write"  # Outputs Prometheus metrics and JSON
 # prometheus_rw_url: ""                                               # Outputs JSON (default)
 
 
@@ -72,7 +72,7 @@ requirements.
 interactively and make contributions.
   - tag `webapp` is the same as main with a [webserver exposed on port 5000][webapp.Dockerfile] that
 serves html reports from the `results` folder, this image have a `run_tests.sh` script that updates
-the folder with a new report. Only works properly when output is JSON.
+the folder with a new report.
 
 If you are on a machine with podman installed, you can use `just run <command>` to execute a
 command from within the main test runner image (tag latest). For example:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # object-storage-tests
+
 A growing test suite for S3-like object storage implementations.
 
 ## About
+
 This project uses the load tests framework [k6][k6] (extended
 with some extensions) as the basis to execute test scenarios using popular
 open source command line tools like [aws-cli][aws-cli], [rclone][rclone],
@@ -9,6 +11,7 @@ open source command line tools like [aws-cli][aws-cli], [rclone][rclone],
 [k6-jslib-aws][k6-jslib-aws].
 
 ### Roadmap
+
 This is an early-stage project and the main focus is to test proprietary
 object storage providers, like AWS and Digital Ocean. But we would like
 to include open source/self-hosted object storage providers as well,
@@ -43,6 +46,22 @@ and edit it to include your credentials.
 cp example.config.yaml config.yaml
 vim config.yaml #edit with your remotes
 ```
+
+### Configuring Output Formats for Test Results
+
+The output format of the test results can be controlled via the `prometheus_rw_url` variable in the `config.yaml` file. This allows for flexibility in how you wish to view and use your test data.
+
+- **JSON Output (Default)**: If the `prometheus_rw_url` variable is not set or is left empty in the `config.yaml`, the test results will be output in JSON format. This is the default behavior and is suitable for scenarios where JSON formatted data is required for analysis or integration, like in a `webapp` tagged image.
+
+- **Prometheus Metrics Output**: If you set a value for `prometheus_rw_url` in the `config.yaml`, the test results will be output as Prometheus metrics. This is useful for integrating with monitoring systems that are compatible with Prometheus.
+
+Example configuration in `config.yaml`:
+
+```yaml
+prometheus_rw_url: "http://your-prometheus-server:port/api/v1/write"  # Outputs Prometheus metrics
+# prometheus_rw_url: ""                                               # Outputs JSON (default)
+
+
 ### Run tests using a pre-made docker image
 
 **object-storage-tests** is available as three
@@ -53,7 +72,7 @@ requirements.
 interactively and make contributions.
   - tag `webapp` is the same as main with a [webserver exposed on port 5000][webapp.Dockerfile] that
 serves html reports from the `results` folder, this image have a `run_tests.sh` script that updates
-the folder with a new report.
+the folder with a new report. Only works properly when output is JSON.
 
 If you are on a machine with podman installed, you can use `just run <command>` to execute a
 command from within the main test runner image (tag latest). For example:
@@ -61,30 +80,40 @@ command from within the main test runner image (tag latest). For example:
 #### list available commands
 
 ```
+
 just run
+
 ```
 
 #### list available remotes
 ```
+
 just run list-remotes
+
 ```
 
 #### list available test scenarios
 ```
+
 just run list-tests
+
 ```
 
 #### run a single test scenario agains a single remote
 
 ```
+
 just run test aws-east-1 boto3-presigned
+
 ```
 
 The output of the tests are stored in a folder named `results`.
 
 #### run the default s3 scenarions on a single remote
 ```
+
 just run test aws-east-1
+
 ```
 
 ### (Optional) mgc cli
@@ -109,17 +138,23 @@ provided dev-shell, using [distrobox][distrobox]:
 
 First assemble the distrobox with:
 ```
+
 just assemble-dev
+
 ```
 
 Then enter it with
 ```
+
 just dev
+
 ```
 
 To run the tests from inside the devshell use:
 ```
+
 just test <remote name>
+
 ```
 
 The devshell is a container with all the project tools installed, plus some
@@ -168,3 +203,4 @@ Check [Dockerfile][Dockerfile] for an up-to-date complete list.
 [devshell.Dockerfile]:./devshell.Dockerfile
 [Dockerfile]:./Dockerfile
 
+```

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -48,6 +48,9 @@ webapp:
 # specific remotes for specific test groups
 small_set_remotes: "do-nyc3 aws-east-1"
 
+# prometheus write endpoint to send metrics to, if empty or null results are default to JSON
+prometheus_rw_url: "http://<prometheus-dns-or-ip>:9090/api/v1/write"
+
 # settings for storing the results in the cloud
 # XXX: add -s3 in the end of the name because the sync is made with rclone
 results_bucket: "aws-east-1-s3:object-storage-tests-results-2024-02"

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -48,7 +48,7 @@ webapp:
 # specific remotes for specific test groups
 small_set_remotes: "do-nyc3 aws-east-1"
 
-# prometheus write endpoint to send metrics to, if empty or null results are default to JSON
+# prometheus write endpoint to send metrics to, if filled will also send prometheus metrics.
 prometheus_rw_url: "http://<prometheus-dns-or-ip>:9090/api/v1/write"
 
 # settings for storing the results in the cloud

--- a/justfile
+++ b/justfile
@@ -184,10 +184,10 @@ _setup: _setup-rclone _setup-aws _setup-mgc
 # run k6 test with env vars and outputs to Prometheus or JSON
 _k6-run remote testname results_dir *args:
   #!/usr/bin/env sh
-  output_arg="--out json="{{results_dir}}/k6-{{testname}}.json""
+  prometheus_output_arg=""
   if [ -n "{{prometheus_rw_url}}" ]; then
     echo "prometheus_rw_url is set and not empty"
-    output_arg="--out=experimental-prometheus-rw"
+    prometheus_output_arg="--out=experimental-prometheus-rw"
   fi
   K6_PROMETHEUS_RW_SERVER_URL="{{prometheus_rw_url}}" \
   k6 run src/k6/{{testname}}.js \
@@ -196,7 +196,8 @@ _k6-run remote testname results_dir *args:
     --quiet \
     --vus={{k6_vus}} --iterations={{k6_iterations}} \
     --env AWS_CLI_PROFILE={{remote}} \
-    $output_arg \
+    $prometheus_output_arg \
+    --out json="{{results_dir}}/k6-{{testname}}.json"
     --console-output="{{results_dir}}/k6-{{testname}}.console.log" \
     {{args}} 2>&1 | tee "{{results_dir}}/k6-{{testname}}.log"
 

--- a/justfile
+++ b/justfile
@@ -181,7 +181,7 @@ _setup-mgc:
 # setup cli tools
 _setup: _setup-rclone _setup-aws _setup-mgc
 
-# run k6 test with env vars and outputs to Prometheus or JSON
+# run k6 test with env vars and outputs to JSON and Prometheus if url is set
 _k6-run remote testname results_dir *args:
   #!/usr/bin/env sh
   prometheus_output_arg=""

--- a/justfile
+++ b/justfile
@@ -17,8 +17,7 @@ oci_manager := env_var_or_default("DBX_CONTAINER_MANAGER", fallback_cm)
 k6_vus := "1"
 k6_iterations := "1"
 
-# Reads Prometheus RW server URL from config.yaml
-prometheus_rw_url := `dasel -f "./config.yaml" 'prometheus_rw_url'`
+
 
 # OCI
 main_image := "ghcr.io/marmotitude/object-storage-tests:main"
@@ -184,12 +183,13 @@ _setup: _setup-rclone _setup-aws _setup-mgc
 # run k6 test with env vars and outputs to JSON and Prometheus if url is set
 _k6-run remote testname results_dir *args:
   #!/usr/bin/env sh
+  prometheus_rw_url := `dasel -f "{{config_file}}" 'prometheus_rw_url'`
   prometheus_output_arg=""
-  if [ -n "{{prometheus_rw_url}}" ]; then
+  if [ -n "$prometheus_rw_url" ]; then
     echo "prometheus_rw_url is set and not empty"
     prometheus_output_arg="--out=experimental-prometheus-rw"
   fi
-  K6_PROMETHEUS_RW_SERVER_URL="{{prometheus_rw_url}}" \
+  K6_PROMETHEUS_RW_SERVER_URL="$prometheus_rw_url" \
   k6 run src/k6/{{testname}}.js \
     --address localhost:0 \
     --tag "remote={{remote}}" \


### PR DESCRIPTION
This PR is a new proposal of output thru a Prometheus server so you can collect metrics on the k6 tests.

It envolves creating a new variable for config.yaml `prometheus_rw_url` that when filled will also send output to a prometheus write endpoint.